### PR TITLE
Handle lat/lon as floats to avoid TypeError

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,8 +47,9 @@ try:
     # IntraTime Data
     INTRA_USER = os.getenv('INTRA_USER')
     INTRA_PASS = os.getenv('INTRA_PASS')
-    LAT = os.getenv('LATITUDE')
-    LON = os.getenv('LONGITUDE')
+    # Convert latitude and longitude to floats to avoid type errors
+    LAT = float(os.getenv('LATITUDE'))
+    LON = float(os.getenv('LONGITUDE'))
 
     bot = TeleBot(TOKEN)
 


### PR DESCRIPTION
## Summary
- Cast `LATITUDE` and `LONGITUDE` env vars to float to prevent math errors during random coordinate calculations

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68924f68863083299a160dcb87266d27