### PR TITLE
Delay intratime clocking until save

### DIFF
--- a/main.py
+++ b/main.py
@@ -419,8 +419,6 @@ def handle_daily_registry(message):
         set_state(STATE, 'REGISTRY', 'site', )
 
     elif STATE['REGISTRY'] == 'site':
-        clocking('in')
-
         log.info(f'Lugar: {message.text}')
         daily_registry.append({'site': message.text,
                                'entry': 450,
@@ -453,7 +451,6 @@ def handle_daily_registry(message):
     elif STATE['REGISTRY'] == 'complete':
         bot.send_message(AUTHORIZED_CHAT, f"Registro completado")
         log.info('Registro completado')
-        clocking('out')
 
         set_state(STATE, 'CURRENT', 'check_registry', )
         message.text = 'Registro'
@@ -514,6 +511,9 @@ def handle_check_registry(message):
 
     elif accion == "Guardar":
         log.info('Guardar datos')
+        if any(reg['site'] not in ['Festivo', 'Vacaciones'] for reg in daily_registry):
+            clocking('in')
+            clocking('out')
 
         data = {
             'name': CONFIG['NAME'],


### PR DESCRIPTION
## Summary
- Trigger intratime check-in and check-out when saving the daily registry
- Skip intratime actions when the day is marked as holiday or vacation

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6892522f1ccc8329a0664c63c6408a48